### PR TITLE
Show problematic html under error

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ var es = require('event-stream'),
 function handleMessages(file, messages) {
 	var success = true,
 		errorText = gutil.colors.red.bold('HTML Error:'),
-		warningText = gutil.colors.yellow.bold('HTML Warning:');
+		warningText = gutil.colors.yellow.bold('HTML Warning:'),
+		lines = file.contents.toString().split(/\r\n|\r|\n/g);
 
 	if (!Array.isArray(messages)) {
 		gutil.log(warningText, 'Failed to run validation on', file.relative);
@@ -31,25 +32,30 @@ function handleMessages(file, messages) {
 			location = 'Line ' + message.lastLine + ', Column ' + message.lastColumn + ':';
 
 		var erroredLine = lines[message.lastLine - 1];
-		var errorColumn = message.lastColumn;
+		if (erroredLine) {//if not, stream was changed since validation
+			var errorColumn = message.lastColumn;
 
-		//trim before if the error is too late in the line
-		if (errorColumn > 60) {
-			erroredLine = erroredLine.slice(errorColumn - 50);
-			errorColumn = 50;
+			//trim before if the error is too late in the line
+			if (errorColumn > 60) {
+				erroredLine = erroredLine.slice(errorColumn - 50);
+				errorColumn = 50;
+			}
+
+			//trim after so the line is not too long
+			erroredLine = erroredLine.slice(0, 60);
+
+			//highlight character with error
+			erroredLine =
+				gutil.colors.grey(erroredLine.substring(0, errorColumn - 1)) +
+				gutil.colors.red.bold(erroredLine[ errorColumn - 1 ]) +
+				gutil.colors.grey(erroredLine.substring(errorColumn));
 		}
 
-		//trim after so the line is not too long
-		erroredLine = erroredLine.slice(0, 60);
-
-		//highlight character with error
-		erroredLine =
-			gutil.colors.grey(erroredLine.substring(0, errorColumn - 1)) +
-			gutil.colors.red.bold(erroredLine[ errorColumn - 1 ]) +
-			gutil.colors.grey(erroredLine.substring(errorColumn));
-
 		gutil.log(type, file.relative, location, message.message);
-		gutil.log(erroredLine);
+
+		if (erroredLine) {
+			gutil.log(erroredLine);
+		}
 	});
 
 	return success;


### PR DESCRIPTION
I don't know how to figure out the line out of a buffer so this only works on one-liners like after the out of [gulp-compressor](https://github.com/steel1990/gulp-compressor), but this is the output.

```
[14:00:28] HTML Error: index.html Line 1, Column 2928: End tag had attributes. 
xit" type="button"></button type="button"> </div>  
                                        ^
```

I thought it would be good to show the code [like the official validator](http://validator.w3.org/check?uri=google.com&charset=%28detect+automatically%29&doctype=Inline&group=0#result). My html files are usually preprocessed by templating systems so columns and line numbers don't match, this means that finding the error takes longer than validating the file manually.
