### PR TITLE
Improved output

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
     "test": "mocha"
   },
   "dependencies": {
-    "gulp-util": "^3.0.3",
-    "through2": "^0.6.3",
-    "w3cjs": "^0.2.0"
+    "gulp-util": "^3.0.5",
+    "through2": "^2.0.0",
+    "w3cjs": "^0.3.0"
   },
   "devDependencies": {
-    "mocha": "^2.1.0",
-    "should": "^5.0.1"
+    "mocha": "^2.2.5",
+    "should": "^6.0.3"
   },
   "engines": {
     "node": ">=0.10.0",

--- a/test/html/no-doctype.html
+++ b/test/html/no-doctype.html
@@ -1,9 +1,0 @@
-<html lang="en">
-<head>
-	<title>Document</title>
-	<meta charset="utf-8">
-</head>
-<body>
-	<h1>Test page</h1>
-</body>
-</html>

--- a/test/main.js
+++ b/test/main.js
@@ -18,11 +18,11 @@ describe('gulp-w3cjs', function () {
 			contents: fs.readFileSync('./test/html/valid.html')
 		});
 
-		var stream = w3cjs();
+		var stream = w3cjs({showInfo: true});
 		stream.on('data', function (newFile) {
 			should.exist(newFile);
 			newFile.w3cjs.success.should.equal(true);
-			newFile.w3cjs.messages.length.should.equal(0);
+			newFile.w3cjs.messages.filter(function(m) { return m.type!=="info"; }).length.should.equal(0);
 			should.exist(newFile.path);
 			should.exist(newFile.relative);
 			should.exist(newFile.contents);
@@ -57,7 +57,7 @@ describe('gulp-w3cjs', function () {
 		stream.on('data', function (newFile) {
 			should.exist(newFile);
 			newFile.w3cjs.success.should.equal(true);
-			newFile.w3cjs.messages.length.should.equal(0);
+			newFile.w3cjs.messages.filter(function(m) { return m.type!=="info"; }).length.should.equal(0);
 			should.exist(newFile.path);
 			should.exist(newFile.relative);
 			should.exist(newFile.contents);
@@ -89,7 +89,7 @@ describe('gulp-w3cjs', function () {
 		stream.on('data', function (newFile) {
 			should.exist(newFile);
 			newFile.w3cjs.success.should.equal(false);
-			newFile.w3cjs.messages.length.should.equal(2);
+			newFile.w3cjs.messages.filter(function(m) { return m.type!=="info"; }).length.should.equal(2);
 			should.exist(newFile.path);
 			should.exist(newFile.relative);
 			should.exist(newFile.contents);

--- a/test/main.js
+++ b/test/main.js
@@ -40,41 +40,6 @@ describe('gulp-w3cjs', function () {
 		stream.end();
 	});
 
-	it('should allow options to be passed', function (done) {
-		var a = 0;
-
-		var fakeFile = new gutil.File({
-			path: './test/html/no-doctype.html',
-			cwd: './test/',
-			base: './test/html/',
-			contents: fs.readFileSync('./test/html/no-doctype.html')
-		});
-
-		var stream = w3cjs({
-			doctype: 'HTML5'
-		});
-
-		stream.on('data', function (newFile) {
-			should.exist(newFile);
-			newFile.w3cjs.success.should.equal(true);
-			newFile.w3cjs.messages.filter(function(m) { return m.type!=="info"; }).length.should.equal(0);
-			should.exist(newFile.path);
-			should.exist(newFile.relative);
-			should.exist(newFile.contents);
-			newFile.path.should.equal('./test/html/no-doctype.html');
-			newFile.relative.should.equal('no-doctype.html');
-			++a;
-		});
-
-		stream.once('end', function () {
-			a.should.equal(1);
-			done();
-		});
-
-		stream.write(fakeFile);
-		stream.end();
-	});
-
 	it('should fail invalid files', function (done) {
 		var a = 0;
 


### PR DESCRIPTION
- Do not print line/column information, when it is not given
- Added info message formatting (new option: showInfo (boolean, default false))
(tests fail because of deprication message, see thomasdavis/w3cjs#18, which is now hidden by default since it is an info message)