### PR TITLE
Fixed documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Error: HTML validation error(s) found
 
 ### w3cjs(options)
 
-#### options.url
+#### options.uri
 
 URL to the w3c validator. Use if you want to use a local validator. This is the
 same thing as `w3cjs.setW3cCheckUrl()`.


### PR DESCRIPTION
The source code is looking for the options.uri string to the validator.
Updated the documentation to reflect the real behaviour.