### PR TITLE
Added 'verifyMessage' function to the options

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,24 @@ Http address of the proxy server if you are running behind a firewall, e.g.  `ht
 
 _`options.doctype` and `options.charset` were dropped in 1.0.0. Use 0.3.0 if you need them._
 
+#### options.verifyMessage
+
+Allows you to intercept info, warnings or errors, using `options.verifyMessage` methed, returning false will skip the log output. Example usage:
+```js
+gulp.src('index.html')
+.pipe(w3cjs({
+	verifyMessage: function(type, message) {
+
+		// prevent logging error message
+		if(message.indexOf('Element “style” not allowed as child of element') === 0) return false;
+		
+		// allow message to pass through
+		return true;
+	}
+}))
+.pipe(w3cjs.reporter())
+```
+
 ### w3cjs.setW3cCheckUrl(url)
 
 Same as options.url. SEt's the URL to the w3c validator.

--- a/index.js
+++ b/index.js
@@ -26,6 +26,10 @@ function handleMessages(file, messages, options) {
 	}
 
 	messages.forEach(function (message) {
+
+		// allows you to intercept info, warnings or errors, using `options.verifyMessage` methed, returning false will skip the log output 
+		if(options.verifyMessage && !options.verifyMessage(message.type, message.message)) return;
+
 		if (message.type === 'info' && !options.showInfo) {
 			return;
 		}

--- a/test/main.js
+++ b/test/main.js
@@ -72,6 +72,42 @@ describe('gulp-w3cjs', function () {
 			stream.write(fakeFile);
 			stream.end();
 		});
+		
+		it('should allow a custom error to be ignored when `options.verifyMessage` used', function(done) {
+			var a = 0;
+
+			var fakeFile = new gutil.File({
+				path: './test/html/invalid.html',
+				cwd: './test/',
+				base: './test/html/',
+				contents: fs.readFileSync('./test/html/invalid.html')
+			});
+
+			var stream = w3cjs({
+				verifyMessage: function(type, message) {
+
+					// prevent logging error message
+					if(message.indexOf('End tag for  “body” seen, but') === 0) return false;
+					if(message.indexOf('Unclosed element “h1”.') === 0) return false;
+					
+					// allow message to pass through
+					return true;
+				}
+			});
+			stream.on('data', function (newFile) {
+				should.exist(newFile);
+				newFile.w3cjs.success.should.equal(true);
+				++a;
+			});
+
+			stream.once('end', function () {
+				a.should.equal(1);
+				done();
+			});
+
+			stream.write(fakeFile);
+			stream.end();
+		})
 	});
 
 	describe('w3cjs.setW3cCheckUrl()', function () {
@@ -120,4 +156,5 @@ describe('gulp-w3cjs', function () {
 			return stream;
 		});
 	});
+
 });


### PR DESCRIPTION
New feature allows you to intercept info, warnings or errors, using `options.verifyMessage` methed, returning false will skip the log output. Useful for errors/logs that you know you know you can safely ignore and don't want them to clutter your command-line on every build.