### PR TITLE
Replace deprecated gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,9 @@
 
 var through = require('through2');
 var w3cjs = require('w3cjs');
-var gutil = require('gulp-util');
+var fancyLog = require('fancy-log');
+var PluginError = require('plugin-error');
+var colors = require('ansi-colors');
 
 /**
  * Handles messages.
@@ -13,13 +15,13 @@ var gutil = require('gulp-util');
  */
 function handleMessages(file, messages, options) {
 	var success = true;
-	var errorText = gutil.colors.red.bold('HTML Error:');
-	var warningText = gutil.colors.yellow.bold('HTML Warning:');
-	var infoText = gutil.colors.green.bold('HTML Info:');
+	var errorText = colors.bold(colors.red('HTML Error:'));
+	var warningText = colors.bold(colors.yellow('HTML Warning:'));
+	var infoText = colors.bold(colors.green('HTML Info:'));
 	var lines = file.contents.toString().split(/\r\n|\r|\n/g);
 
 	if (!Array.isArray(messages)) {
-		gutil.log(warningText, 'Failed to run validation on', file.relative);
+		fancyLog(warningText, 'Failed to run validation on', file.relative);
 
 		// Not sure whether this should be true or false
 		return true;
@@ -59,19 +61,19 @@ function handleMessages(file, messages, options) {
 
 			// Highlight character with error
 			erroredLine =
-				gutil.colors.grey(erroredLine.substring(0, errorColumn - 1)) +
-				gutil.colors.red.bold(erroredLine[ errorColumn - 1 ]) +
-				gutil.colors.grey(erroredLine.substring(errorColumn));
+				colors.grey(erroredLine.substring(0, errorColumn - 1)) +
+				colors.bold(colors.red(erroredLine[ errorColumn - 1 ])) +
+				colors.grey(erroredLine.substring(errorColumn));
 		}
 
 		if (typeof(message.lastLine) !== 'undefined' || typeof(lastColumn) !== 'undefined') {
-			gutil.log(type, file.relative, location, message.message);
+			fancyLog(type, file.relative, location, message.message);
 		} else {
-			gutil.log(type, file.relative, message.message);
+			fancyLog(type, file.relative, message.message);
 		}
 
 		if (erroredLine) {
-			gutil.log(erroredLine);
+			fancyLog(erroredLine);
 		}
 	});
 
@@ -82,7 +84,7 @@ function reporter() {
 	return through.obj(function(file, enc, cb) {
         cb(null, file);
         if (file.w3cjs && !file.w3cjs.success) {
-            throw new gutil.PluginError('gulp-w3cjs', 'HTML validation error(s) found');
+            throw new PluginError('gulp-w3cjs', 'HTML validation error(s) found');
         }
     });
 }
@@ -105,7 +107,7 @@ module.exports = function (options) {
 		}
 
 		if (file.isStream()) {
-			return callback(new gutil.PluginError('gulp-w3cjs', 'Streaming not supported'));
+			return callback(new PluginError('gulp-w3cjs', 'Streaming not supported'));
 		}
 
 		w3cjs.validate({

--- a/package.json
+++ b/package.json
@@ -25,13 +25,16 @@
     "test": "mocha"
   },
   "dependencies": {
-    "gulp-util": "^3.0.5",
+    "ansi-colors": "^1.0.1",
+    "fancy-log": "^1.3.2",
+    "plugin-error": "^1.0.1",
     "through2": "^2.0.0",
     "w3cjs": "^0.3.0"
   },
   "devDependencies": {
     "mocha": "^2.2.5",
-    "should": "^6.0.3"
+    "should": "^6.0.3",
+    "vinyl": "^2.1.0"
   },
   "engines": {
     "node": ">=0.10.0",

--- a/test/main.js
+++ b/test/main.js
@@ -3,8 +3,9 @@
 
 var fs = require('fs');
 var should = require('should');
+var path = require('path');
 
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 var w3cjs = require('../');
 
 describe('gulp-w3cjs', function () {
@@ -12,7 +13,7 @@ describe('gulp-w3cjs', function () {
 		it('should pass valid files', function (done) {
 			var a = 0;
 
-			var fakeFile = new gutil.File({
+			var fakeFile = new Vinyl({
 				path: './test/html/valid.html',
 				cwd: './test/',
 				base: './test/html/',
@@ -27,7 +28,7 @@ describe('gulp-w3cjs', function () {
 				should.exist(newFile.path);
 				should.exist(newFile.relative);
 				should.exist(newFile.contents);
-				newFile.path.should.equal('./test/html/valid.html');
+				newFile.path.should.equal(path.normalize('./test/html/valid.html'));
 				newFile.relative.should.equal('valid.html');
 				++a;
 			});
@@ -44,7 +45,7 @@ describe('gulp-w3cjs', function () {
 		it('should fail invalid files', function (done) {
 			var a = 0;
 
-			var fakeFile = new gutil.File({
+			var fakeFile = new Vinyl({
 				path: './test/html/invalid.html',
 				cwd: './test/',
 				base: './test/html/',
@@ -59,7 +60,7 @@ describe('gulp-w3cjs', function () {
 				should.exist(newFile.path);
 				should.exist(newFile.relative);
 				should.exist(newFile.contents);
-				newFile.path.should.equal('./test/html/invalid.html');
+				newFile.path.should.equal(path.normalize('./test/html/invalid.html'));
 				newFile.relative.should.equal('invalid.html');
 				++a;
 			});
@@ -76,7 +77,7 @@ describe('gulp-w3cjs', function () {
 		it('should allow a custom error to be ignored when `options.verifyMessage` used', function(done) {
 			var a = 0;
 
-			var fakeFile = new gutil.File({
+			var fakeFile = new Vinyl({
 				path: './test/html/invalid.html',
 				cwd: './test/',
 				base: './test/html/',
@@ -118,7 +119,7 @@ describe('gulp-w3cjs', function () {
 
 	describe('w3cjs.reporter()', function () {
 		it('should pass files through', function () {
-			var fakeFile = new gutil.File({
+			var fakeFile = new Vinyl({
 				path: './test/html/valid.html',
 				cwd: './test/',
 				base: './test/html/',
@@ -133,7 +134,7 @@ describe('gulp-w3cjs', function () {
 		});
 
 		it('should contain a reporter by default', function () {
-			var fakeFile = new gutil.File({
+			var fakeFile = new Vinyl({
 				path: './test/html/invalid.html',
 				cwd: './test/',
 				base: './test/html/',


### PR DESCRIPTION
[`gulp-util`](https://www.npmjs.com/package/gulp-util) has been deprecated recently. Continuing to use this dependency may prevent the use of your library with the recently released version 4 of Gulp, **it is important to replace `gulp-util`**.

Your package is popular but still relying on `gulp-util`, it would be good to publish a fixed version to npm as soon as possible.

See:
- https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
- https://github.com/gulpjs/gulp-util/issues/143